### PR TITLE
left / right press fix

### DIFF
--- a/UIMenu/UIMenu.lua
+++ b/UIMenu/UIMenu.lua
@@ -714,7 +714,7 @@ function UIMenu:ProcessControl()
         end
     end
     if not self.LeftPressed then
-        if self.Controls.Left.Enabled and (IsDisabledControlPressed(0, 174) or IsDisabledControlPressed(1, 174) or IsDisabledControlPressed(2, 174)) then
+        if self.Controls.Left.Enabled and (IsDisabledControlJustPressed(0, 174) or IsDisabledControlJustPressed(1, 174) or IsDisabledControlJustPressed(2, 174)) then
             local type, subtype = self.Items[self:CurrentSelection()]()
             Citizen.CreateThread(function()
                 if (subtype == "UIMenuSliderHeritageItem") then
@@ -732,7 +732,7 @@ function UIMenu:ProcessControl()
                     Citizen.Wait(175)
                     while self.Controls.Left.Enabled and (IsDisabledControlPressed(0, 174) or IsDisabledControlPressed(1, 174) or IsDisabledControlPressed(2, 174)) do
                         self:GoLeft()
-                        Citizen.Wait(175)
+                        Citizen.Wait(125)
                     end
                     self.LeftPressed = false
                 end
@@ -740,7 +740,7 @@ function UIMenu:ProcessControl()
         end
     end
     if not self.RightPressed then
-        if self.Controls.Right.Enabled and (IsDisabledControlPressed(0, 175) or IsDisabledControlPressed(1, 175) or IsDisabledControlPressed(2, 175)) then
+        if self.Controls.Right.Enabled and (IsDisabledControlJustPressed(0, 175) or IsDisabledControlJustPressed(1, 175) or IsDisabledControlJustPressed(2, 175)) then
             Citizen.CreateThread(function()
                 local type, subtype = self.Items[self:CurrentSelection()]()
                 if (subtype == "UIMenuSliderHeritageItem") then
@@ -758,7 +758,7 @@ function UIMenu:ProcessControl()
                     Citizen.Wait(175)
                     while self.Controls.Right.Enabled and (IsDisabledControlPressed(0, 175) or IsDisabledControlPressed(1, 175) or IsDisabledControlPressed(2, 175)) do
                         self:GoRight()
-                        Citizen.Wait(175)
+                        Citizen.Wait(125)
                     end
                     self.RightPressed = false
                 end


### PR DESCRIPTION
prevents double-registering of initial left/right keypress

previous edit to wait time during keypress is not necessary

actual issue is that sometimes left/right keypress is registered twice, creating two threads, duplicating all actions in that direction until the key is released