### PR TITLE
meta-hub patch 1

### DIFF
--- a/src/NativeUIReloaded.lua
+++ b/src/NativeUIReloaded.lua
@@ -439,6 +439,13 @@ function MenuPool.New()
     return setmetatable(_MenuPool, MenuPool)
 end
 
+--Remove
+--@return nil
+--@public
+function MenuPool:Remove()
+    self = nil
+end
+
 ---AddSubMenu
 ---@param Menu table
 ---@param Text string

--- a/src/UIMenu/MenuPool.lua
+++ b/src/UIMenu/MenuPool.lua
@@ -14,6 +14,13 @@ function MenuPool.New()
     return setmetatable(_MenuPool, MenuPool)
 end
 
+--Remove
+--@return nil
+--@public
+function MenuPool:Remove()
+    self = nil
+end
+
 ---AddSubMenu
 ---@param Menu table
 ---@param Text string


### PR DESCRIPTION
# Pull request Details
Addition from Frazzles' NativeUILua that seems to have resolved the memory leak caused by spam opening a menu on hotkey.

## Description
`MenuPool:Remove()` function added.
Original NativeUILua commit found here:
https://github.com/FrazzIe/NativeUILua/pull/11/commits/3c99ab3195115f9172fac1dc17f9ba0e317f5bdb

## Related Issue
https://github.com/iTexZoz/NativeUILua_Reloaded/issues/68

## Motivation and Context
Couldn't use it myself without finding a fix for this issue.

## How Has This Been Tested
I tested this by repeatedly opening and closing a large vehicle shop menu that is reconstructed each time its opened. My resource monitor has shown no higher then 10mb of memory usage.

## Types of changes
Addition of function.

## Example usage
```
OpenMenu = function()
  if _Pool then _Pool:Remove(); end
  _Pool = NativeUI.CreatePool()
  _Menu = NativeUI.CreateMenu("My Menu","My Description")
  _Pool:Add(_Menu)
end
```
Calling of MenuPool:Remove() and creating a new pool, along with a new menu, every time you want to open a a menu seems to resolve the memory leak.